### PR TITLE
Increase timeout again

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -20,7 +20,7 @@ $time\
 [\\$](fg:#909090) 
 """
 
-command_timeout = 500
+command_timeout = 750
 
 # Disable the blank line at the start of the prompt
 # add_newline = true


### PR DESCRIPTION
Some commands were still timing out on mac, try a longer timeout.