### PR TITLE
Prevent commands started with space from being saved to the Zsh history

### DIFF
--- a/rc/zsh-mac/zshrc
+++ b/rc/zsh-mac/zshrc
@@ -1,3 +1,6 @@
+# Prevent commands started with a space from being saved to $HOME/.zsh_history
+setopt HIST_IGNORE_SPACE
+
 # Aliases
 if [ -f ~/.zsh/zshaliases ]; then
     source ~/.zsh/zshaliases


### PR DESCRIPTION
Self-explanatory