### PR TITLE
Rewrite starship config

### DIFF
--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -1,65 +1,83 @@
 # Get editor completions based on the config schema
-#"$schema" = 'https://starship.rs/config-schema.json'
+# "$schema" = 'https://starship.rs/config-schema.json'
 
-# Symbols codes: https://www.nerdfonts.com/cheat-sheet
+# Symbols used (https://www.nerdfonts.com/cheat-sheet)
+# e0b4 , e0ba , e0bc , e0b0 , e691 , # f007 , f07c , e0a0 , f017 , f00ed 󰃭, e0c6 , f075a 󰝚
+
+# Hints
+# * When a string is enclosed by parenthesis, it doesn't render if all variables inside are None or empty
+# * prev_bg and prev_fg are valid values for colors
+
+# Pastel
+#903284 #FFFFFF
+#D65B71 #FFFFFF
+#F0986F #000000
+#7AB2D3 #000000
+#2C597F #FFFFFF
+#D0D0D0
+
+# Blue
+#3B237A #FFFFFF
+#33658A #FFFFFF
+#86BBD8 #000000
+#ABABAB #000000
+#B497FF
+
+# Rainbow
+#064A74 #FFFFFF
+#7E1014 #FFFFFF
+#B30020 #FFFFFF
+#DD962C #000000
+#FAD300 #000000
+#00D000
+
+# Optional first section
+#[  ](fg:#FFFFFF bg:#903284)\
+#[](fg:prev_bg bg:#3B237A)$username\
 
 format = """
-[ \uf007 ](bg:#3B237A fg:#FFFFFF)$username\
-[\ue0b4](bg:#33658A fg:#3B237A)\
-[ \uf07c](bg:#33658A fg:#FFFFFF)\
-$directory\
-[\ue0b4](bg:#86BBD8 fg:#33658A)\
-[ \ue0a0](fg:#000000 bg:#86BBD8)\
-$git_branch\
-$git_status\
-[\ue0b4](fg:#86BBD8 bg:#ABABAB)\
-[ \uf017](bg:#ABABAB fg:#000000)\
-$time\
-[\ue0b4](fg:#ABABAB)
+$username\
+[](fg:prev_bg bg:#33658A)$directory\
+([](fg:prev_bg bg:#7AB2D3)$git_branch$git_status)\
+[](fg:prev_bg bg:#ABABAB)$time
 [>](fg:#B497FF) 
 """
 
 command_timeout = 750
 
-# Disable the blank line at the start of the prompt
-# add_newline = true
+add_newline = true
 
 # You can also replace your username with a neat symbol like  to save some space
 [username]
 show_always = true
-style_user = "fg:#ffffff bg:#3B237A"
-style_root = "fg:#ffffff bg:#3B237A"
-format = '[$user ]($style)'
+style_user = "fg:#FFFFFF bg:#3B237A"
+style_root = "fg:#FFFFFF bg:#3B237A"
+format = "[  $user ]($style)"
 
 [directory]
-style = "fg:#ffffff bg:#33658A"
-format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
+style = "fg:#000000 bg:#33658A"
+format = "[  $path ]($style)"
 
 # Here is how you can shorten some long paths by text replacement
 # similar to mapped_locations in Oh My Posh:
 [directory.substitutions]
 "Documents" = "📄 "
 "Downloads" = "📥 "
-"Music" = "🎜 "
+"Music" = "󰝚 "
 "Pictures" = "📷 "
-# Keep in mind that the order matters. For example:
-# "Important Documents" = "  "
-# will not be replaced, because "Documents" was already substituted before.
-# So either put "Important Documents" before "Documents" or use the substituted version:
-# "Important  " = "  "
 
 [git_branch]
 style = "fg:#000000 bg:#86BBD8"
-format = '[[ $branch ](fg:#000000 bg:#86BBD8)]($style)'
+format = "[  $branch ]($style)"
 
 [git_status]
 style = "fg:#000000 bg:#86BBD8"
-format = '[[($all_status$ahead_behind )](bg:#86BBD8 fg:#000000)]($style)'
+format = '[$all_status$ahead_behind ]($style)'
 
 [time]
 disabled = false
-time_format = "%T CW%V" # Hour:Minute:Second CalendarWeek
+time_format = "%T 󰃭 CW%V" # Hour:Minute:Second  CalendarWeek
 style = "fg:#000000 bg:#ABABAB"
-format = '[[ $time ](fg:#000000 bg:#ABABAB)]($style)'
+format = "[  $time [](#ABABAB)]($style)"


### PR DESCRIPTION
Introduce a series of small improvements that in combination simplify the configuration file. Some of the changes in more details:
* Use the symbols directly instead of their unicode. Given the text editor is using the same font as the terminal emulator, it's possible to check if the symbol will be rendered correctly in advance
* Document the "themes" used
* Use the pre-defined color variables pre_bg and pre_fg to avoid repeating colors
* Use conditional rendering (`()`) for the git sections
* Properly use the style variable in some section to avoid repetition