### PR TITLE
Increase Ghostty background opacity to 0.95

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -53,4 +53,4 @@ background = #1D1D1D
 # # Just for example:
 # resize-overlay-duration = 4s 200ms
 
-background-opacity = 0.9
+background-opacity = 0.95


### PR DESCRIPTION
The previous value (0.9) was slightly too transparent so it was getting a bit confusing.