### PR TITLE
Adjust 'c' alias and create one for 'clear' that clears only screen

### DIFF
--- a/rc/aliases
+++ b/rc/aliases
@@ -4,7 +4,8 @@
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -lah'
-alias c='clear'
+alias c='printf "\e[H\e[22J"' # Clears screen but not scrollback
+alias clear=c
 
 # CD that also works with a number argument, that makes it go N directories up in the hierarchy
 function cdx() {


### PR DESCRIPTION
By specification the clear command cleans both screen and scrollback. Ghostty, differently than other terminal emulators, implement this according to the spec resulting in a super unintuitive and user unfriendly experience.

With this PR a different alias for `c` is introduced. This alias prints "\e[H\e[22J" achieving the desired behavior of clearing screen but not scrollback. Additionally, it also introduces an alias for `clear` that simply calls `c`.