### PR TITLE
Use alternative clear alias when Ghostty is used

### DIFF
--- a/rc/aliases
+++ b/rc/aliases
@@ -4,8 +4,13 @@
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -lah'
-alias c='printf "\e[H\e[22J"' # Clears screen but not scrollback
-alias clear=c
+# Only where Ghostty is used (not Windows)
+if ! uname -a | grep -i microsoft > /dev/null 2>&1; then
+    alias c='printf "\e[H\e[22J"' # Clears screen but not scrollback
+    alias clear=c
+else
+    alias c='clear'
+fi
 
 # CD that also works with a number argument, that makes it go N directories up in the hierarchy
 function cdx() {


### PR DESCRIPTION
While Ghostty follows specification when treating the clear command its behavior is extremely unintuitive and user unfriendly. Therefore an alias was created to make it behave exactly as other terminal emulators. This PR changes the alias to be conditionally enabled only in the situations where Ghostty is being used, i.e. not on Windows.